### PR TITLE
External dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ bundle, err := mf.NewBundle(
     mf.WithLangFallback(language.BritishEnglish, language.English),
     mf.WithLangFallback(language.Portuguese, language.Spanish),
 
+    // Load all yaml files in directory as messages
+    mf.WithYamlProvider(messagesDir),
+
+    // or you could use your own custom message provider
+    // mf.WithProvider(sqlMessageProvider),
 
     // We assume that the translated messages are mostly correct.
     // However, if any errors occur during translation,
@@ -77,12 +82,6 @@ bundle, err := mf.NewBundle(
     }),
 )
 
-if err != nil {
-    log.Fatal(err)
-}
-
-// Load all yaml files in directory as messages
-err = bundle.LoadDir(messagesDir)
 if err != nil {
     log.Fatal(err)
 }
@@ -131,16 +130,13 @@ func main() {
 		mf.WithLangFallback(language.BritishEnglish, language.English),
 		mf.WithLangFallback(language.Portuguese, language.Spanish),
 
+                mf.WithYamlProvider(messagesDir),
+
 		mf.WithErrorHandler(func(err error, id string, ctx map[string]any) {
 			slog.Error(err.Error(), slog.String("id", id), slog.Any("ctx", ctx))
 		}),
 	)
 
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	err = bundle.LoadDir(messagesDir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ func main() {
 		mf.WithLangFallback(language.BritishEnglish, language.English),
 		mf.WithLangFallback(language.Portuguese, language.Spanish),
 
-                mf.WithYamlProvider(messagesDir),
+		mf.WithYamlProvider(messagesDir),
 
 		mf.WithErrorHandler(func(err error, id string, ctx map[string]any) {
 			slog.Error(err.Error(), slog.String("id", id), slog.Any("ctx", ctx))

--- a/example/base/main.go
+++ b/example/base/main.go
@@ -20,6 +20,8 @@ func main() {
 		mf.WithLangFallback(language.BritishEnglish, language.English),
 		mf.WithLangFallback(language.Portuguese, language.Spanish),
 
+		mf.WithFSProvider(messagesDir),
+
 		mf.WithErrorHandler(func(err error, id string, ctx map[string]any) {
 			slog.Error(err.Error(), slog.String("id", id), slog.Any("ctx", ctx))
 
@@ -28,11 +30,6 @@ func main() {
 		}),
 	)
 
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	err = bundle.LoadDir(messagesDir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example/base/main.go
+++ b/example/base/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	"log"
 	"log/slog"
 	"math/rand/v2"
 
@@ -31,7 +30,7 @@ func main() {
 	)
 
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
 	tr := bundle.Translator("en")

--- a/example/base/main.go
+++ b/example/base/main.go
@@ -20,7 +20,7 @@ func main() {
 		mf.WithLangFallback(language.BritishEnglish, language.English),
 		mf.WithLangFallback(language.Portuguese, language.Spanish),
 
-		mf.WithFSProvider(messagesDir),
+		mf.WithYamlProvider(messagesDir),
 
 		mf.WithErrorHandler(func(err error, id string, ctx map[string]any) {
 			slog.Error(err.Error(), slog.String("id", id), slog.Any("ctx", ctx))

--- a/example/base/var/messages.es.yaml
+++ b/example/base/var/messages.es.yaml
@@ -6,8 +6,8 @@ subtitle: >-
   }
 
 say:
-  hello: Hello, {name}!
-  goodbye: Goodbye, {name}!
+  hello: Hola, {name}!
+  goodbye: Adiós, {name}!
 
 user:
   profile:

--- a/message/plural.go
+++ b/message/plural.go
@@ -88,7 +88,7 @@ func (p *Plural) Eval(ctx Context) (string, error) {
 	}
 
 	if p.Offset > 0 {
-		offset := uint64(p.Offset)
+		offset := uint64(p.Offset) //nolint: gosec
 		if offset < np.i {
 			np.i -= offset
 		} else {
@@ -124,27 +124,27 @@ func toPluralForm(num any) (pm, error) {
 		if i < 0 {
 			i = -i
 		}
-		return pm{i: uint64(i)}, nil
+		return pm{i: uint64(i)}, nil //nolint: gosec
 	case int8:
 		if i < 0 {
 			i = -i
 		}
-		return pm{i: uint64(i)}, nil
+		return pm{i: uint64(i)}, nil //nolint: gosec
 	case int16:
 		if i < 0 {
 			i = -i
 		}
-		return pm{i: uint64(i)}, nil
+		return pm{i: uint64(i)}, nil //nolint: gosec
 	case int32:
 		if i < 0 {
 			i = -i
 		}
-		return pm{i: uint64(i)}, nil
+		return pm{i: uint64(i)}, nil //nolint: gosec
 	case int64:
 		if i < 0 {
 			i = -i
 		}
-		return pm{i: uint64(i)}, nil
+		return pm{i: uint64(i)}, nil //nolint: gosec
 	case uint:
 		return pm{i: uint64(i)}, nil
 	case uint8:

--- a/mf/bundle.go
+++ b/mf/bundle.go
@@ -170,6 +170,18 @@ func WithDefaulLangFallback(l language.Tag) BundleOption {
 	}
 }
 
+func LoadDictionariesFromFS(dir fs.FS) BundleOption {
+	return func(b *bundle) {
+		b.LoadDir(dir)
+	}
+}
+
+func WithDictionary(lang language.Tag, d Dictionary) BundleOption {
+	return func(b *bundle) {
+		b.dictionaries[lang] = d
+	}
+}
+
 func WithLangFallback(from language.Tag, to language.Tag) BundleOption {
 	return func(b *bundle) {
 		b.fallbacks[from] = to

--- a/mf/bundle.go
+++ b/mf/bundle.go
@@ -12,10 +12,9 @@ type Bundle interface {
 }
 
 type bundle struct {
-	fallbacks    map[language.Tag]language.Tag
-	translators  map[language.Tag]Translator
-	dictionaries map[language.Tag]Dictionary
-	provider     Provider
+	fallbacks   map[language.Tag]language.Tag
+	translators map[language.Tag]Translator
+	provider    MessageProvider
 
 	defaultLang         language.Tag
 	defaultErrorHandler ErrorHandler
@@ -27,9 +26,8 @@ type BundleOption func(b *bundle) error
 
 func NewBundle(options ...BundleOption) (Bundle, error) {
 	bundle := &bundle{
-		fallbacks:    map[language.Tag]language.Tag{},
-		translators:  map[language.Tag]Translator{},
-		dictionaries: map[language.Tag]Dictionary{},
+		fallbacks:   map[language.Tag]language.Tag{},
+		translators: map[language.Tag]Translator{},
 
 		defaultLang:         language.Und,
 		defaultErrorHandler: func(_ error, _ string, _ map[string]any) {},
@@ -97,26 +95,18 @@ func WithDefaulLangFallback(l language.Tag) BundleOption {
 	}
 }
 
-func WithFSProvider(dir fs.FS) BundleOption {
+func WithYamlProvider(dir fs.FS) BundleOption {
 	return func(b *bundle) error {
-		provider, err := NewFSProvider(dir)
+		provider, err := NewYamlMessageProvider(dir)
 		b.provider = provider
 
 		return err
 	}
 }
 
-func WithProvider(provider Provider) BundleOption {
+func WithProvider(provider MessageProvider) BundleOption {
 	return func(b *bundle) error {
 		b.provider = provider
-
-		return nil
-	}
-}
-
-func WithDictionary(lang language.Tag, d Dictionary) BundleOption {
-	return func(b *bundle) error {
-		b.dictionaries[lang] = d
 
 		return nil
 	}

--- a/mf/bundle_test.go
+++ b/mf/bundle_test.go
@@ -25,39 +25,36 @@ func TestNewBundle(t *testing.T) {
 
 func TestWithDefaulLangFallback(t *testing.T) {
 	b := &bundle{
-		fallbacks:    map[language.Tag]language.Tag{},
-		translators:  map[language.Tag]Translator{},
-		dictionaries: map[language.Tag]Dictionary{},
+		fallbacks:   map[language.Tag]language.Tag{},
+		translators: map[language.Tag]Translator{},
 
 		defaultLang:         language.Und,
 		defaultErrorHandler: func(_ error, _ string, _ map[string]any) {},
 	}
 
 	assert.Equal(t, language.Und, b.defaultLang)
-	WithDefaulLangFallback(language.Afrikaans)(b)
+	require.NoError(t, WithDefaulLangFallback(language.Afrikaans)(b))
 	assert.Equal(t, language.Afrikaans, b.defaultLang)
 }
 
 func TestWithLangFallback(t *testing.T) {
 	b := &bundle{
-		fallbacks:    map[language.Tag]language.Tag{},
-		translators:  map[language.Tag]Translator{},
-		dictionaries: map[language.Tag]Dictionary{},
+		fallbacks:   map[language.Tag]language.Tag{},
+		translators: map[language.Tag]Translator{},
 
 		defaultLang:         language.Und,
 		defaultErrorHandler: func(_ error, _ string, _ map[string]any) {},
 	}
 
 	assert.Equal(t, language.Und, b.fallbacks[language.AmericanEnglish])
-	WithLangFallback(language.AmericanEnglish, language.English)(b)
+	require.NoError(t, WithLangFallback(language.AmericanEnglish, language.English)(b))
 	assert.Equal(t, language.English, b.fallbacks[language.AmericanEnglish])
 }
 
 func TestWithErrorHandler(t *testing.T) {
 	b := &bundle{
-		fallbacks:    map[language.Tag]language.Tag{},
-		translators:  map[language.Tag]Translator{},
-		dictionaries: map[language.Tag]Dictionary{},
+		fallbacks:   map[language.Tag]language.Tag{},
+		translators: map[language.Tag]Translator{},
 
 		defaultLang:         language.Und,
 		defaultErrorHandler: func(_ error, _ string, _ map[string]any) {},
@@ -65,7 +62,7 @@ func TestWithErrorHandler(t *testing.T) {
 
 	assert.NotNil(t, b.defaultErrorHandler)
 	errHandler := func(_ error, _ string, _ map[string]any) {}
-	WithErrorHandler(errHandler)(b)
+	require.NoError(t, WithErrorHandler(errHandler)(b))
 
 	funcName1 := runtime.FuncForPC(reflect.ValueOf(errHandler).Pointer()).Name()
 	funcName2 := runtime.FuncForPC(reflect.ValueOf(b.defaultErrorHandler).Pointer()).Name()
@@ -85,7 +82,7 @@ func TestBundle_Translator(t *testing.T) {
 	b, err = NewBundle(
 		WithDefaulLangFallback(language.English),
 		WithLangFallback(language.Portuguese, language.Spanish),
-		WithFSProvider(fstest.MapFS{
+		WithYamlProvider(fstest.MapFS{
 			"messages.en.yaml": {Data: []byte("foo: en\nbar_id: enbar")},
 			"messages.es.yaml": {Data: []byte("foo: es")},
 		}),

--- a/mf/bundle_test.go
+++ b/mf/bundle_test.go
@@ -1,12 +1,12 @@
 package mf
 
 import (
-	"io/fs"
 	"reflect"
 	"runtime"
 	"testing"
 	"testing/fstest"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/text/language"
@@ -16,6 +16,7 @@ func TestNewBundle(t *testing.T) {
 	b, err := NewBundle(
 		WithDefaulLangFallback(language.English),
 		WithLangFallback(language.Portuguese, language.Spanish),
+		WithProvider(new(MockedProvider)),
 	)
 
 	require.NoError(t, err)
@@ -71,81 +72,25 @@ func TestWithErrorHandler(t *testing.T) {
 	assert.Equal(t, funcName1, funcName2)
 }
 
-func TestBundle_LoadMessages(t *testing.T) {
-	b := &bundle{
-		fallbacks:    map[language.Tag]language.Tag{},
-		translators:  map[language.Tag]Translator{},
-		dictionaries: map[language.Tag]Dictionary{},
-
-		defaultLang:         language.Und,
-		defaultErrorHandler: func(_ error, _ string, _ map[string]any) {},
-	}
-
-	fs := fstest.MapFS{
-		"non_readable": {
-			Mode: fs.ModeDir,
-		},
-		"foo.en.yaml": {
-			Data: []byte("foo: bar"),
-		},
-	}
-
-	require.Error(t, b.LoadMessages(fs, "file_not_exists.yaml", language.English))
-	assert.Nil(t, b.dictionaries[language.English])
-
-	require.Error(t, b.LoadMessages(fs, "non_readable", language.English))
-	assert.Nil(t, b.dictionaries[language.English])
-
-	require.NoError(t, b.LoadMessages(fs, "foo.en.yaml", language.English))
-	assert.NotNil(t, b.dictionaries[language.English])
-
-	require.Error(t, b.LoadMessages(fs, "foo.en.yaml", language.English), "error when lang already loaded")
-	assert.NotNil(t, b.dictionaries[language.English])
-}
-
-func TestBundle_LoadDir(t *testing.T) {
-	b := &bundle{
-		fallbacks:    map[language.Tag]language.Tag{},
-		translators:  map[language.Tag]Translator{},
-		dictionaries: map[language.Tag]Dictionary{},
-
-		defaultLang:         language.Und,
-		defaultErrorHandler: func(_ error, _ string, _ map[string]any) {},
-	}
-
-	require.NoError(t, b.LoadDir(fstest.MapFS{"dir.en": {Mode: fs.ModeDir}}), "no error on empty fs")
-	assert.Nil(t, b.dictionaries[language.English], "does not loads dirs")
-
-	require.NoError(t, b.LoadDir(fstest.MapFS{"messages.en.toml": {Data: []byte("foo=bar")}}), "no error on non yaml files")
-	assert.Nil(t, b.dictionaries[language.English], "but does not loads them")
-
-	require.Error(t, b.LoadDir(fstest.MapFS{".yaml": {Data: []byte("foo: bar")}}), "error on invalid filename")
-	require.Error(t, b.LoadDir(fstest.MapFS{"messages.FOO.yaml": {Data: []byte("foo: bar")}}), "error on invalid lang in filename")
-
-	require.NoError(t, b.LoadDir(fstest.MapFS{
-		"messages.en.yaml": {Data: []byte("foo: bar")},
-		"messages.es.yaml": {Data: []byte("foo: bar")},
-		"messages.ru.yml":  {Data: []byte("foo: bar")},
-	}), "no error on normal yaml files")
-	assert.NotNil(t, b.dictionaries[language.English])
-	assert.NotNil(t, b.dictionaries[language.Spanish])
-	assert.NotNil(t, b.dictionaries[language.Russian])
-}
-
 func TestBundle_Translator(t *testing.T) {
-	b, _ := NewBundle()
+	provider := new(MockedProvider)
+	b, err := NewBundle(WithProvider(provider))
+	require.NoError(t, err)
 	assert.NotNil(t, b.Translator("ru"), "even empty bundle returns some translator")
+
+	provider.On("Get", language.Russian, "msg_id").Return("", errors.New("no message")) // call from actual translator
+	provider.On("Get", language.Und, "msg_id").Return("", errors.New("no message"))     // call from fallback translator
 	assert.Equal(t, "msg_id", b.Translator("ru").Trans("msg_id"), "even empty bundle returns some translator")
 
-	b, _ = NewBundle(
+	b, err = NewBundle(
 		WithDefaulLangFallback(language.English),
 		WithLangFallback(language.Portuguese, language.Spanish),
+		WithFSProvider(fstest.MapFS{
+			"messages.en.yaml": {Data: []byte("foo: en\nbar_id: enbar")},
+			"messages.es.yaml": {Data: []byte("foo: es")},
+		}),
 	)
-
-	require.NoError(t, b.LoadDir(fstest.MapFS{
-		"messages.en.yaml": {Data: []byte("foo: en\nbar_id: enbar")},
-		"messages.es.yaml": {Data: []byte("foo: es")},
-	}))
+	require.NoError(t, err)
 
 	assert.Equal(t, "en", b.Translator("en").Trans("foo"), "en loaded from file")
 	assert.Equal(t, "en", b.Translator("pl").Trans("foo"), "fallback to defalt lang")

--- a/mf/dictionary.go
+++ b/mf/dictionary.go
@@ -10,14 +10,14 @@ type Dictionary interface {
 	Get(path string) (string, error)
 }
 
-type dummyDictionary struct{}
+type DummyDictionary struct{}
 
-func (*dummyDictionary) Get(id string) (string, error) {
+func (*DummyDictionary) Get(id string) (string, error) {
 	return "", fmt.Errorf("no message with id %s", id)
 }
 
-func NewDictionary(yaml []byte) (Dictionary, error) {
-	d := &dictionary{
+func NewYamlDictionary(yaml []byte) (*YamlDictionary, error) {
+	d := &YamlDictionary{
 		flatMap: map[string]string{},
 	}
 
@@ -33,11 +33,11 @@ func NewDictionary(yaml []byte) (Dictionary, error) {
 	return d, nil
 }
 
-type dictionary struct {
+type YamlDictionary struct {
 	flatMap map[string]string
 }
 
-func (d *dictionary) Get(id string) (string, error) {
+func (d *YamlDictionary) Get(id string) (string, error) {
 	msg, ok := d.flatMap[id]
 	if !ok {
 		return "", fmt.Errorf("no message with id %s", id)
@@ -46,7 +46,7 @@ func (d *dictionary) Get(id string) (string, error) {
 	return msg, nil
 }
 
-func (d *dictionary) buildFlatMap(prefix string, yn *y3.Node) {
+func (d *YamlDictionary) buildFlatMap(prefix string, yn *y3.Node) {
 	for i := 0; i < len(yn.Content); i++ {
 		n := yn.Content[i]
 

--- a/mf/dictionary_test.go
+++ b/mf/dictionary_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDictionaryGet(t *testing.T) {
-	d, err := NewDictionary([]byte(`
+	d, err := NewYamlDictionary([]byte(`
 one:
     two: msg1-2
 foo: bar
@@ -100,7 +100,7 @@ foo:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := NewDictionary(tt.yaml)
+			d, err := NewYamlDictionary(tt.yaml)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewDictionary() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/mf/provider.go
+++ b/mf/provider.go
@@ -1,0 +1,87 @@
+package mf
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"path"
+	"strings"
+
+	"github.com/pkg/errors"
+	"golang.org/x/text/language"
+)
+
+type Provider interface {
+	Get(lang language.Tag, path string) (string, error)
+}
+
+type FSProvider struct {
+	dictionaries map[language.Tag]Dictionary
+}
+
+func (p *FSProvider) Get(lang language.Tag, path string) (string, error) {
+	d, hasDictionary := p.dictionaries[lang]
+	if !hasDictionary {
+		return "", errors.Errorf("no dictionary for lang %s", lang)
+	}
+
+	return d.Get(path)
+}
+
+func NewFSProvider(dir fs.FS) (*FSProvider, error) {
+	provider := FSProvider{
+		dictionaries: map[language.Tag]Dictionary{},
+	}
+
+	err := fs.WalkDir(dir, ".", func(p string, f fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if f.IsDir() {
+			return nil
+		}
+
+		if path.Ext(f.Name()) != ".yaml" && path.Ext(f.Name()) != ".yml" {
+			return nil
+		}
+
+		nameParts := strings.Split(f.Name(), ".")
+		if len(nameParts) < 2 {
+			return fmt.Errorf("no lang in file %s", f.Name())
+		}
+
+		tag, err := language.Parse(nameParts[len(nameParts)-2])
+		if err != nil {
+			return errors.Wrap(err, "unable to parse language from filename")
+		}
+
+		return provider.loadMessages(dir, p, tag)
+	})
+
+	return &provider, err
+}
+
+func (p *FSProvider) loadMessages(rd fs.FS, path string, lang language.Tag) error {
+	yamlFile, err := rd.Open(path)
+	if err != nil {
+		return errors.Wrap(err, "unable to open file")
+	}
+
+	yamlData, err := io.ReadAll(yamlFile)
+	if err != nil {
+		return errors.Wrap(err, "unable to read file")
+	}
+
+	_, hasDictionary := p.dictionaries[lang]
+	if hasDictionary {
+		return fmt.Errorf("unable to load %s: language %s already has messages loaded", path, lang)
+	}
+
+	p.dictionaries[lang], err = NewDictionary(yamlData)
+	if err != nil {
+		return errors.Wrap(err, "unable to create dictionary")
+	}
+
+	return nil
+}

--- a/mf/provider_test.go
+++ b/mf/provider_test.go
@@ -11,21 +11,21 @@ import (
 )
 
 func TestNewFSProvider(t *testing.T) {
-	p, err := NewFSProvider(fstest.MapFS{"dir.en": {Mode: fs.ModeDir}})
+	p, err := NewYamlMessageProvider(fstest.MapFS{"dir.en": {Mode: fs.ModeDir}})
 	require.NoError(t, err, "no error on empty fs")
 	assert.Empty(t, p.dictionaries, "does not loads dirs")
 
-	p, err = NewFSProvider(fstest.MapFS{"messages.en.toml": {Data: []byte("foo=bar")}})
+	p, err = NewYamlMessageProvider(fstest.MapFS{"messages.en.toml": {Data: []byte("foo=bar")}})
 	require.NoError(t, err, "no error on non yaml files")
 	assert.Empty(t, p.dictionaries, "but does not loads them")
 
-	_, err = NewFSProvider(fstest.MapFS{".yaml": {Data: []byte("foo: bar")}})
+	_, err = NewYamlMessageProvider(fstest.MapFS{".yaml": {Data: []byte("foo: bar")}})
 	require.Error(t, err, "error on invalid filename")
 
-	_, err = NewFSProvider(fstest.MapFS{"messages.FOO.yaml": {Data: []byte("foo: bar")}})
+	_, err = NewYamlMessageProvider(fstest.MapFS{"messages.FOO.yaml": {Data: []byte("foo: bar")}})
 	require.Error(t, err, "error on invalid lang in filename")
 
-	p, err = NewFSProvider(fstest.MapFS{
+	p, err = NewYamlMessageProvider(fstest.MapFS{
 		"messages.en.yaml": {Data: []byte("foo: bar")},
 		"messages.es.yaml": {Data: []byte("foo: bar")},
 		"messages.ru.yml":  {Data: []byte("foo: bar")},
@@ -38,8 +38,8 @@ func TestNewFSProvider(t *testing.T) {
 }
 
 func TestFSProvider_loadMessages(t *testing.T) {
-	p := &FSProvider{
-		dictionaries: map[language.Tag]Dictionary{},
+	p := &YamlMessageProvider{
+		dictionaries: map[language.Tag]*YamlDictionary{},
 	}
 	fs := fstest.MapFS{
 		"non_readable": {

--- a/mf/provider_test.go
+++ b/mf/provider_test.go
@@ -1,0 +1,64 @@
+package mf
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
+)
+
+func TestNewFSProvider(t *testing.T) {
+	p, err := NewFSProvider(fstest.MapFS{"dir.en": {Mode: fs.ModeDir}})
+	require.NoError(t, err, "no error on empty fs")
+	assert.Empty(t, p.dictionaries, "does not loads dirs")
+
+	p, err = NewFSProvider(fstest.MapFS{"messages.en.toml": {Data: []byte("foo=bar")}})
+	require.NoError(t, err, "no error on non yaml files")
+	assert.Empty(t, p.dictionaries, "but does not loads them")
+
+	_, err = NewFSProvider(fstest.MapFS{".yaml": {Data: []byte("foo: bar")}})
+	require.Error(t, err, "error on invalid filename")
+
+	_, err = NewFSProvider(fstest.MapFS{"messages.FOO.yaml": {Data: []byte("foo: bar")}})
+	require.Error(t, err, "error on invalid lang in filename")
+
+	p, err = NewFSProvider(fstest.MapFS{
+		"messages.en.yaml": {Data: []byte("foo: bar")},
+		"messages.es.yaml": {Data: []byte("foo: bar")},
+		"messages.ru.yml":  {Data: []byte("foo: bar")},
+	})
+	require.NoError(t, err, "no error on normal yaml files")
+	assert.NotEmpty(t, p.dictionaries, "has dictionaries")
+	assert.NotNil(t, p.dictionaries[language.English])
+	assert.NotNil(t, p.dictionaries[language.Spanish])
+	assert.NotNil(t, p.dictionaries[language.Russian])
+}
+
+func TestFSProvider_loadMessages(t *testing.T) {
+	p := &FSProvider{
+		dictionaries: map[language.Tag]Dictionary{},
+	}
+	fs := fstest.MapFS{
+		"non_readable": {
+			Mode: fs.ModeDir,
+		},
+		"foo.en.yaml": {
+			Data: []byte("foo: bar"),
+		},
+	}
+
+	require.Error(t, p.loadMessages(fs, "file_not_exists.yaml", language.English))
+	assert.Nil(t, p.dictionaries[language.English])
+
+	require.Error(t, p.loadMessages(fs, "non_readable", language.English))
+	assert.Nil(t, p.dictionaries[language.English])
+
+	require.NoError(t, p.loadMessages(fs, "foo.en.yaml", language.English))
+	assert.NotNil(t, p.dictionaries[language.English])
+
+	require.Error(t, p.loadMessages(fs, "foo.en.yaml", language.English), "error when lang already loaded")
+	assert.NotNil(t, p.dictionaries[language.English])
+}

--- a/mf/translator.go
+++ b/mf/translator.go
@@ -15,6 +15,7 @@ type Translator interface {
 }
 
 type translator struct {
+	provider     Provider
 	dictionary   Dictionary
 	fallback     Translator
 	errorHandler ErrorHandler
@@ -22,7 +23,7 @@ type translator struct {
 }
 
 func (tr *translator) Trans(id string, args ...TranslationArg) string {
-	yaml, err := tr.dictionary.Get(id)
+	yaml, err := tr.provider.Get(tr.lang, id)
 	if err != nil {
 		if tr.fallback != nil {
 			return tr.fallback.Trans(id, args...)

--- a/mf/translator.go
+++ b/mf/translator.go
@@ -15,8 +15,7 @@ type Translator interface {
 }
 
 type translator struct {
-	provider     Provider
-	dictionary   Dictionary
+	provider     MessageProvider
 	fallback     Translator
 	errorHandler ErrorHandler
 	lang         language.Tag

--- a/mf/translator_test.go
+++ b/mf/translator_test.go
@@ -469,13 +469,15 @@ func Test_translator_Trans(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dictionary := new(MockedDictionary)
-			dictionary.On("Get", "msg_id").Return(tt.msg, nil)
+			provider := new(MockedProvider)
+			provider.On("Get", tt.lang, "msg_id").Return(tt.msg, nil)
+
+			t.Log(len(provider.ExpectedCalls))
 
 			var testErr error
 
 			tr := &translator{
-				dictionary: dictionary,
+				provider: provider,
 				errorHandler: func(err error, _ string, _ map[string]any) {
 					t.Log(err.Error())
 					testErr = err
@@ -493,6 +495,16 @@ func Test_translator_Trans(t *testing.T) {
 			}
 		})
 	}
+}
+
+type MockedProvider struct {
+	mock.Mock
+}
+
+func (m *MockedProvider) Get(lang language.Tag, path string) (string, error) {
+	args := m.Called(lang, path)
+
+	return args.String(0), args.Error(1)
 }
 
 type MockedDictionary struct {


### PR DESCRIPTION
Fix #13 

```go
type MessageProvider interface {
  Get(lang language.Tag, msgPath string) (string, error)
}

provider := ... // my custom sql message provider

bundle, err := mf.NewBundle(
    mf.WithProvider(provider),
)

// or simple
bundle, err := mf.NewBundle(
    mf.WithYamlProvider(messagesDir), // embed yaml dictionary
)
```