### PR TITLE
Add support for choosing best match translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ trEs := bundle.Translator("es")
 trEs.Trans("say_hello", mf.Arg("name", "Aníbal"))
 ```
 
+Find the best translation from user preferences
+
+```go
+
+handler( w http.ResponseWriter, r *http.Request) {
+    langCookie, _ := r.Cookie("lang")
+	// langCookie = "es-AR"
+	acceptHeader := r.Header.Get("Accept-Language")
+	// acceptHeader = "da, en-gb;q=0.8, en;q=0.7"
+	
+	tr := bundle.Translator(langCookie, acceptHeader)
+	// tr will translate to the closest matching language, e.g. Spanish, "es"
+}
+```
+
 <details>
   <summary>Full example</summary>
 

--- a/mf/provider.go
+++ b/mf/provider.go
@@ -15,8 +15,14 @@ type MessageProvider interface {
 	Get(lang language.Tag, id string) (string, error)
 }
 
+type LanguagesProvider interface {
+	MessageProvider
+	Languages() []language.Tag
+}
+
 type YamlMessageProvider struct {
 	dictionaries map[language.Tag]*YamlDictionary
+	languages    []language.Tag
 }
 
 func (p *YamlMessageProvider) Get(lang language.Tag, path string) (string, error) {
@@ -26,6 +32,10 @@ func (p *YamlMessageProvider) Get(lang language.Tag, path string) (string, error
 	}
 
 	return d.Get(path)
+}
+
+func (p *YamlMessageProvider) Languages() []language.Tag {
+	return p.languages
 }
 
 func NewYamlMessageProvider(dir fs.FS) (*YamlMessageProvider, error) {
@@ -82,6 +92,6 @@ func (p *YamlMessageProvider) loadMessages(rd fs.FS, path string, lang language.
 	if err != nil {
 		return errors.Wrap(err, "unable to create dictionary")
 	}
-
+	p.languages = append(p.languages, lang)
 	return nil
 }


### PR DESCRIPTION
This adds language.MatchStrings() support to Bundle.Translator.

If a bundle contains "en" and "es" translations then `bundle.Translator("es-AR")` will return the translator for "es", while `bundle.Translator("de", "da, en-gb;q=0.8, en;q=0.7") will return a translator for "en".

This makes handling translations for web apps easy, where there may be explicit languages set in cookies or url parameters, and client preferences set in the `Accept-Languages` header.

The main user-visible change is that Bundle.Translator() can accept any number of strings rather than one.

The main implementation change is adding an optional Languages() function to a MessageProvider, returning a list of languages that provider supports, and using that to create a language.Matcher for bundle.Translator to use.

Tests and README have been updated to match.